### PR TITLE
Player looks a horizon instead of ground initially...

### DIFF
--- a/src/contexts/Render/render.ts
+++ b/src/contexts/Render/render.ts
@@ -133,7 +133,7 @@ export async function $INIT_RENDER() {
 
   const camera = DVER.render.getDefaultCamera(scene);
   camera.position.y = 70;
-  camera.setTarget(Vector3.Zero());
+  camera.setTarget(new Vector3(0, 90, 90));
   camera.inertia = 0.2;
   BabylonSystem.camera = camera;    ;
   // camera.maxZ = 1000;


### PR DESCRIPTION
... which makes initial mouse capture less awkward. Otherwise it is kind of hard to not break blocks when trying to first have the canvas capture mouse movement.